### PR TITLE
Fixed bug with undefined filePath variable in Service::save method

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -44,7 +44,7 @@ class Service
         return $this;
     }
 
-    public function save($filepath = 'export.pdf')
+    public function save($filePath = 'export.pdf')
     {
         if(file_put_contents($filePath, $this->exportContent)) {
             return $this;
@@ -82,10 +82,10 @@ class Service
         header("Content-Disposition: $disposition; filename=\"$filename\"");
         header("Content-Transfer-Encoding: binary");
         header("Content-Length: " . strlen($this->exportContent));
-        
+
         echo $this->exportContent;
 
         return $this;
     }
-    
+
 }


### PR DESCRIPTION
Have got and error trying use Client::save with undefined variable. This pull request fixes it.
![image](https://user-images.githubusercontent.com/13361839/89767437-984fb700-db02-11ea-8d8a-04256d91284c.png)
